### PR TITLE
Create Flip Reverse It, Blazing Squad

### DIFF
--- a/Flip Reverse It, Blazing Squad
+++ b/Flip Reverse It, Blazing Squad
@@ -1,0 +1,16 @@
+fetch NodeList from @node 1:1 and create SVGmap;
+request EventListeners (Discord: App, Invoice),
+set var "Factor Invoice" count *(items); 
+HAving (Users.UserID, UserID.items); GROUP BY User ID HAVING > = 3*items;
+REQUEST TargetID.Targets if User ID HAVING > = 3*items;
+COUNT xrange ITERATE (TargetID, Pathway);
+ser VAR = Pathway;
+Ab=a; b=Ub; Ub=[ ]; for [c=0, c<b.length; c++) b(c)(a)}ya= function (a) {a: if (js:test(local: global variable)
+is global variable
+elif ref https://sync.spotin.market/cosync?
+set visitor.omnitagjs.com
+ref visitor.omnitagjs.com;
+console.log (Pathway); isSecureContext?;
+elif REQUEST ChannelNodeSplitter 
+
+


### PR DESCRIPTION
From my conversations with VMWare...
a concise argument against idle IP traces/ callbacks


"cancelIdleCallback
ƒ cancelIdleCallback() { [native code] }
ChannelSplitterNode, request(NodeList, port:62,); request SVGSwitchElement, import (node map) {iterate: local.localvariable, global.globalvariable; export {nodemap_SVGmapelement};
VM200:1 Uncaught SyntaxError: missing ) after argument list
releaseEvents, reportError, if isSecureContext export SVGSwitchElement; 
elif request import ListenerEvents for ChannelSplitterNode; traceback @cosync @omnitag 
console.log(bidderID, co-location);
VM324:1 Uncaught SyntaxError: 
elif NodeIterator {NodeList} PermissionStatus is 
 SecurityPolicyViolationEvent export listenerevents;
VM546:1 Uncaught SyntaxError: Unexpected identifier
export GeolocationPositionError;
VM579:1 Uncaught SyntaxError: Unexpected token 'export'
import listenerevents;
VM693:1 Uncaught SyntaxError: Cannot use import statement outside a module"
